### PR TITLE
Make RefactorSession.prototype.replace only count changed nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,11 +73,12 @@ class RefactorSession {
     const replacement =
       typeof program === "string" ? parseScript(program) : null;
 
-    nodes.forEach(node => {
+    const replacedNodes=nodes.filter(node => {
       if (isFunction(program)) {
         const rv = program(node);
+        if(rv===node) return false;
         if (isShiftNode(rv)) {
-          this._queueReplacement(node, program(node));
+          this._queueReplacement(node, rv);
         } else if (isString(rv)) {
           const returnedTree = parseScript(rv);
           if (isStatement(node)) {
@@ -98,10 +99,11 @@ class RefactorSession {
           copy(replacement.statements[0].expression)
         );
       }
+      return true;
     });
 
     if (this.autoCleanup) this.cleanup();
-    return nodes.length;
+    return replacedNodes.length;
   }
   replaceRecursive(selector, program) {
     const nodesReplaced = this.replace(selector, program);


### PR DESCRIPTION
Currently, the following code causes `shift-refactor` to crash (infinite recursion):
```js
const {parseScript}=require("shift-parser");
const RefactorSession=require("shift-refactor");
const script=`
window['example string with spaces'];
`;
const session=new RefactorSession(parseScript(script));
session.convertComputedToStatic();
```
Example code [here](https://runkit.com/embed/5t8xd3wbw1am)
It happens because `RefactorSession.prototype.convertComputedToStatic` uses `RefactorSession.prototype.replaceRecursive`, and its replacement program returns the original node in certain cases. When the `expression.value` of a `ComputedMemberExpression` or any of its variants contains a space, the function will return the original node (signifying that there should be no replacement). When `RefactorSession.prototype.replace` is run in `RefactorSession.prototype.replaceRecursive`, the nodes that were not replaced are still counted in the number of replacements. This means that even though there are no more nodes to replace, `RefactorSession.prototype.replaceRecursive` runs again. This PR solves the issue by changing `RefactorSession.prototype.replace` to count only changed nodes.