### PR TITLE
fix advanced example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ This script takes the obfuscated source and turns it into something much more re
 
 ```js
 const { refactor } = require('.'); // require('shift-refactor');
+const { commonMethods } = require('refactor-plugin-common'); // required to use convertComputedToStatic
 const Shift = require('shift-ast');
 
 // Obfuscated source
 const src = `var a=['\x74\x61\x72\x67\x65\x74','\x73\x65\x74\x54\x61\x72\x67\x65\x74','\x77\x6f\x72\x6c\x64','\x67\x72\x65\x65\x74','\x72\x65\x61\x64\x65\x72'];var b=function(c,d){c=c-0x0;var e=a[c];return e;};(function(){class c{constructor(d){this[b('0x0')]=d;}['\x67\x72\x65\x65\x74'](){console['\x6c\x6f\x67']('\x48\x65\x6c\x6c\x6f\x20'+this[b('0x0')]);}[b('0x1')](e){this['\x74\x61\x72\x67\x65\x74']=e;}}const f=new c(b('0x2'));f[b('0x3')]();f[b('0x1')](b('0x4'));f[b('0x3')]();}());`;
 
-const $script = refactor(src);
+const $script = refactor(src, commonMethods);
 
 const strings = $script(`Script > :first-child ArrayExpression > .elements`);
 


### PR DESCRIPTION
I'm also not sure if it's me making a mistake somewhere,
but the following line of code doesn't seem to work for me:

```javascript
const findIndex = (c, d) => c - destringifyOffset.first().value;
```

Seems the `first` function is returning pretty much the same as what `destringifyOffset`
already gives me at that point. The following does work for me:

```javascript
const findIndex = (c, d) => c - destringifyOffset.nodes[0].value;
```

Didn't modify that in the README example in this PR yet, as I do not know if it's a bug, desired or something I'm simply doing wrong.