### PR TITLE
Updated the advanced example in the readme, so it will actually work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,27 @@ strings.forEach(string => console.log(string));
 This script takes the obfuscated source and turns it into something much more readable.
 
 ```js
-const { refactor } = require('.'); // require('shift-refactor');
+const { refactor } = require('shift-refactor');
+const { commonMethods } = require('refactor-plugin-common');
 const Shift = require('shift-ast');
 
 // Obfuscated source
 const src = `var a=['\x74\x61\x72\x67\x65\x74','\x73\x65\x74\x54\x61\x72\x67\x65\x74','\x77\x6f\x72\x6c\x64','\x67\x72\x65\x65\x74','\x72\x65\x61\x64\x65\x72'];var b=function(c,d){c=c-0x0;var e=a[c];return e;};(function(){class c{constructor(d){this[b('0x0')]=d;}['\x67\x72\x65\x65\x74'](){console['\x6c\x6f\x67']('\x48\x65\x6c\x6c\x6f\x20'+this[b('0x0')]);}[b('0x1')](e){this['\x74\x61\x72\x67\x65\x74']=e;}}const f=new c(b('0x2'));f[b('0x3')]();f[b('0x1')](b('0x4'));f[b('0x3')]();}());`;
 
-const $script = refactor(src);
+const $script = refactor(src, commonMethods);
 
 const strings = $script(`Script > :first-child ArrayExpression > .elements`);
 
+// Variable `b` pointing to anonymous function.
 const destringifyDeclarator = $script(`VariableDeclarator[binding.name="b"][init.params.items.length=2]`);
 
 destringifyDeclarator.rename('destringify');
 
+
 const destringifyOffset = destringifyDeclarator.$(`BinaryExpression > LiteralNumericExpression`);
 
-const findIndex = (c, d) => c - destringifyOffset.first().value;
+// Get that anonymous function its `c` variable offset value (0x0).
+const findIndex = (c, d) => c - destringifyOffset.nodes[0].value;
 
 $script(`CallExpression[callee.name="destringify"]`).replace(
   node => {
@@ -81,9 +85,11 @@ $script(`CallExpression[callee.name="destringify"]`).replace(
   }
 )
 
+// Cleanup; remove no longer needed destringify function and remove the string array it uses.
 $script(`[binding.name="a"]`).delete();
 $script(`[binding.name="destringify"]`).delete();
 
+// Turn computed member expressions into static member expressions.
 $script.convertComputedToStatic();
 
 console.log($script.print());


### PR DESCRIPTION
It was broken, since the `convertComputedToStatic` method was moved to `refactor-plugin-common`. The `.first()` method seems broken as well. It has therefore been replaced with `.nodes[0]`. Added a bit more comments as well.